### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "ipython>=8.32.0",
-    "lief==0.15.0",
+    "lief==0.17.0",
     "ruff>=0.9.7",
 ]
 


### PR DESCRIPTION
upgrading lief from 0.15.0 to 0.17.0 so that it builds on current macos with Python 3.14.2